### PR TITLE
bump default k8s version value

### DIFF
--- a/.opspec/build-azure/create-aks/op.yml
+++ b/.opspec/build-azure/create-aks/op.yml
@@ -37,7 +37,7 @@ inputs:
   k8sVersion:
     string:
       constraints: { minLength: 1 }
-      default: 1.11.5
+      default: 1.12.6
   clusterAccountId:
     string:
       constraints: { minLength: 1 }

--- a/.opspec/build-azure/op.yml
+++ b/.opspec/build-azure/op.yml
@@ -40,7 +40,7 @@ inputs:
     string:
       constraints: { minLength: 1 }
       description: kubernetes version of aks cluster used as cmc
-      default: 1.11.5
+      default: 1.12.6
   clusterAccountId:
     string:
       constraints: { minLength: 1 }


### PR DESCRIPTION
Bumped the kubernetes version used by the build-azure ops to the latest version '1.12.6'

Resolves #47 