### PR TITLE
add instancetype to api

### DIFF
--- a/internal/apiserver/cluster.go
+++ b/internal/apiserver/cluster.go
@@ -68,6 +68,7 @@ func (s *Server) CreateCluster(ctx context.Context, in *pb.CreateClusterMsg) (*p
 			},
 			Spec: v1alpha.MachineSpec{
 				Roles: []common.MachineRoles{common.MachineRoleMaster, common.MachineRoleEtcd},
+				InstanceType: machineConfig.InstanceType,
 			},
 		}
 
@@ -94,6 +95,7 @@ func (s *Server) CreateCluster(ctx context.Context, in *pb.CreateClusterMsg) (*p
 			},
 			Spec: v1alpha.MachineSpec{
 				Roles: []common.MachineRoles{common.MachineRoleWorker},
+				InstanceType: machineConfig.InstanceType,
 			},
 		}
 


### PR DESCRIPTION
When making an api call to create a cluster the `cnctmachine` resource will now include the provided instanceType.