### PR TITLE
Fix /etc/fstab commenting out swap in user_data

### DIFF
--- a/pkg/controller/machine/create.go
+++ b/pkg/controller/machine/create.go
@@ -333,7 +333,7 @@ write_files:
 
 runcmd:
  - [ sh, -c, "swapoff -a" ]
- - [ sh, -c, "sed -i.bak '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab"]
+ - [ sh, -c, "sed -ri.bak '/ swap / s/^(.*)$/#\1/g' /etc/fstab"]
  - [ sh, -c, "tar xf /etc/kubernetes/pki/certs.tar -C /etc/kubernetes/pki" ]
  - [ sh, -c, "kubeadm init --node-name {{ .Name }}  --config /var/tmp/masterconfig.yaml" ]
  - [ sh, -c, "kubectl --kubeconfig /etc/kubernetes/admin.conf apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml" ]
@@ -386,7 +386,7 @@ write_files:
 
 runcmd:
  - [ sh, -c, "swapoff -a" ]
- - [ sh, -c, "sed -i.bak '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab"]
+ - [ sh, -c, "sed -ri.bak '/ swap / s/^(.*)$/#\1/g' /etc/fstab"]
  - [ sh, -c, "kubeadm join --node-name {{ .Name }} --config /var/tmp/workerconfig.yaml" ]
 
 output : { all : '| tee -a /var/log/cloud-init-output.log' }


### PR DESCRIPTION
FIX: see jira HS19-236 for bug that this attempts to fix.

attempts to fix bug from log:
```
2019-06-04 08:02:59,786 - util.py[WARNING]: Failed loading yaml blob. Invalid format at line 25 column 14: "while scanning a double-quoted scalar
  in "<unicode string>", line 25, column 14:
     - [ sh, -c, "sed -i.bak '/ swap / s/^\(.*\)$ ...
                 ^
found unknown escape character '('
  in "<unicode string>", line 25, column 40:
     ... , -c, "sed -i.bak '/ swap / s/^\(.*\)$/#\1/g' /etc/fstab"]
                                         ^"
```

Signed-off-by: Jim Conner <snafu.x@gmail.com>